### PR TITLE
fix: makes crop health client work

### DIFF
--- a/src/main/java/io/openepi/crop_health/ApiClient.java
+++ b/src/main/java/io/openepi/crop_health/ApiClient.java
@@ -905,7 +905,7 @@ public class ApiClient {
             // ensuring a default content type
             contentType = "application/json";
         }
-        if (isJsonMime(contentType)) {
+        if (isJsonMime(contentType) || contentType.startsWith("text/plain")) {
             return JSON.deserialize(respBody, returnType);
         } else if (returnType.equals(String.class)) {
             // Expecting string, return the raw response body.

--- a/src/main/java/io/openepi/crop_health/api/DefaultApi.java
+++ b/src/main/java/io/openepi/crop_health/api/DefaultApi.java
@@ -243,6 +243,7 @@ public class DefaultApi {
         }
 
         final String[] localVarContentTypes = {
+                "image/jpeg"
         };
         final String localVarContentType = localVarApiClient.selectHeaderContentType(localVarContentTypes);
         if (localVarContentType != null) {


### PR DESCRIPTION
The generated api client did not accept the contentType that the crop health api returns. This fixes that.