### PR TITLE
fix: Give more sensible names to most public methods for all apis

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Works on Java 8 (and higher)
 import io.openepi.client.CropHealthApi;
 import io.openepi.client.ApiException;
 import io.openepi.crop_health.model.BinaryPredictionResponse;
+import java.io.File;
 
 public class Main {
     public static void main(String[] args) {
@@ -52,6 +53,7 @@ public class Main {
 ```
 
 ### Deforestation
+
 ```java
 import io.openepi.common.ApiException;
 import io.openepi.deforestation.api.DeforestationApi;
@@ -66,7 +68,7 @@ public class Main {
         try {
             BigDecimal lon = new BigDecimal("30.06");
             BigDecimal lat = BigDecimal.valueOf(-1.94);
-            DeforestationBasinGeoJSON response = api.lossyearBasinGetSinglePoint(lon, lat);
+            DeforestationBasinGeoJSON response = api.getLossyearBasinSinglePoint(lon, lat);
             System.out.println(response.getFeatures());
         } catch (ApiException e) {
             System.err.println("Exception when calling DeforestationApi#lossyearBasinGet");
@@ -77,6 +79,7 @@ public class Main {
 ```
 
 ### Flood
+
 ```java
 import io.openepi.flood.api.FloodApi;
 import io.openepi.flood.model.SummaryResponseModel;
@@ -90,7 +93,7 @@ public class Main {
         try {
             BigDecimal lon = new BigDecimal("33.57");
             BigDecimal lat = BigDecimal.valueOf(-1.37);
-            SummaryResponseModel response = api.summarySummaryGetSinglePoint(lon, lat, false);
+            SummaryResponseModel response = api.getForecastSummarySinglePoint(lon, lat, false);
             System.out.println(response.getQueriedLocation().getFeatures());
         } catch (ApiException e) {
             System.err.println("Exception when calling FloodApi#getFlood");
@@ -101,6 +104,7 @@ public class Main {
 ```
 
 ### Geocoding
+
 ```java
 import io.openepi.geocoding.api.GeocodingApi;
 import io.openepi.geocoding.model.FeatureCollection;
@@ -110,7 +114,7 @@ public class Main {
     public static void main(String[] args) {
         GeocodingApi api = new GeocodingApi();
         try {
-            FeatureCollection response = api.geocodingGet("Rwanda");
+            FeatureCollection response = api.getGeocoding("Rwanda");
             System.out.println(response);
         } catch (ApiException e) {
             System.err.println("Exception when calling GeocodingApi#getGeocoding");
@@ -122,6 +126,7 @@ public class Main {
 ```
 
 ### Soil
+
 ```java
 import io.openepi.soil.api.SoilApi;
 import io.openepi.soil.model.SoilTypeJSON;
@@ -135,7 +140,7 @@ public class Main {
         BigDecimal lat = new BigDecimal("60.1");
         SoilApi api = new SoilApi();
         try {
-            SoilTypeJSON response = api.getSoilTypeTypeGet(lon, lat, null);
+            SoilTypeJSON response = api.getSoilType(lon, lat, null);
             System.out.println(response);
         } catch (ApiException e) {
             System.err.println("Exception when calling SoilApi#getSoil");
@@ -147,6 +152,7 @@ public class Main {
 ```
 
 ### Weather
+
 ```java
 import io.openepi.weather.api.WeatherApi;
 import io.openepi.weather.model.METJSONForecast;
@@ -161,7 +167,7 @@ public class Main {
 
         WeatherApi api = new WeatherApi();
         try {
-            METJSONForecast response = api.getForecastLocationforecastGet(lat, lon, null);
+            METJSONForecast response = api.getLocationForecast(lat, lon, null);
             System.out.println(response.getProperties().getTimeseries().get(0).getData().getInstant().getDetails());
         } catch (ApiException e) {
             System.err.println("Exception when calling WeatherApi#getWeather");

--- a/src/main/java/io/openepi/crop_health/api/CropHealthApi.java
+++ b/src/main/java/io/openepi/crop_health/api/CropHealthApi.java
@@ -274,7 +274,7 @@ public class CropHealthApi {
         <tr><td> 200 </td><td> Predicted class confidences, all summing to 1.0. </td><td>  -  </td></tr>
      </table>
      */
-    public BinaryPredictionResponse predictionsWithBinary(File body) throws ApiException {
+    public BinaryPredictionResponse postPredictionBinary(File body) throws ApiException {
         ApiResponse<BinaryPredictionResponse> localVarResp = predictionsWithBinaryWithHttpInfo(body);
         return localVarResp.getData();
     }
@@ -316,7 +316,7 @@ public class CropHealthApi {
         <tr><td> 200 </td><td> Predicted class confidences, all summing to 1.0. </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call predictionsWithBinaryAsync(File body, final ApiCallback<BinaryPredictionResponse> _callback) throws ApiException {
+    public okhttp3.Call postPredictionBinaryAsync(File body, final ApiCallback<BinaryPredictionResponse> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = predictionsWithBinaryValidateBeforeCall(body, _callback);
         Type localVarReturnType = new TypeToken<BinaryPredictionResponse>(){}.getType();
@@ -408,7 +408,7 @@ public class CropHealthApi {
         <tr><td> 200 </td><td> Predicted class confidences, all summing to 1.0. </td><td>  -  </td></tr>
      </table>
      */
-    public MultiHLTPredictionResponse predictionsWithMultiHLT(File body) throws ApiException {
+    public MultiHLTPredictionResponse postPredictionMulti(File body) throws ApiException {
         ApiResponse<MultiHLTPredictionResponse> localVarResp = predictionsWithMultiHLTWithHttpInfo(body);
         return localVarResp.getData();
     }
@@ -450,7 +450,7 @@ public class CropHealthApi {
         <tr><td> 200 </td><td> Predicted class confidences, all summing to 1.0. </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call predictionsWithMultiHLTAsync(File body, final ApiCallback<MultiHLTPredictionResponse> _callback) throws ApiException {
+    public okhttp3.Call postPredictionMultiAsync(File body, final ApiCallback<MultiHLTPredictionResponse> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = predictionsWithMultiHLTValidateBeforeCall(body, _callback);
         Type localVarReturnType = new TypeToken<MultiHLTPredictionResponse>(){}.getType();
@@ -542,7 +542,7 @@ public class CropHealthApi {
         <tr><td> 200 </td><td> Predicted class confidences, all summing to 1.0. </td><td>  -  </td></tr>
      </table>
      */
-    public SingleHLTPredictionResponse predictionsWithSingleHLT(File body) throws ApiException {
+    public SingleHLTPredictionResponse postPredictionSingle(File body) throws ApiException {
         ApiResponse<SingleHLTPredictionResponse> localVarResp = predictionsWithSingleHLTWithHttpInfo(body);
         return localVarResp.getData();
     }
@@ -584,7 +584,7 @@ public class CropHealthApi {
         <tr><td> 200 </td><td> Predicted class confidences, all summing to 1.0. </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call predictionsWithSingleHLTAsync(File body, final ApiCallback<SingleHLTPredictionResponse> _callback) throws ApiException {
+    public okhttp3.Call postPredictionSingleAsync(File body, final ApiCallback<SingleHLTPredictionResponse> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = predictionsWithSingleHLTValidateBeforeCall(body, _callback);
         Type localVarReturnType = new TypeToken<SingleHLTPredictionResponse>(){}.getType();

--- a/src/main/java/io/openepi/deforestation/api/DeforestationApi.java
+++ b/src/main/java/io/openepi/deforestation/api/DeforestationApi.java
@@ -19,17 +19,12 @@ import io.openepi.common.ApiCallback;
 import io.openepi.common.ApiException;
 import io.openepi.common.ApiResponse;
 import io.openepi.common.Pair;
-import io.openepi.common.ProgressRequestBody;
-import io.openepi.common.ProgressResponseBody;
 
 import com.google.gson.reflect.TypeToken;
-
-import java.io.IOException;
 
 
 import java.math.BigDecimal;
 import io.openepi.deforestation.model.DeforestationBasinGeoJSON;
-import io.openepi.deforestation.model.HTTPValidationError;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -196,7 +191,7 @@ public class DeforestationApi {
         <tr><td> 422 </td><td> Validation Error </td><td>  -  </td></tr>
      </table>
      */
-    public DeforestationBasinGeoJSON lossyearBasinGet(BigDecimal lon, BigDecimal lat, BigDecimal minLon, BigDecimal minLat, BigDecimal maxLon, BigDecimal maxLat, Integer startYear, Integer endYear) throws ApiException {
+    public DeforestationBasinGeoJSON getLossyearBasin(BigDecimal lon, BigDecimal lat, BigDecimal minLon, BigDecimal minLat, BigDecimal maxLon, BigDecimal maxLat, Integer startYear, Integer endYear) throws ApiException {
         ApiResponse<DeforestationBasinGeoJSON> localVarResp = lossyearBasinGetWithHttpInfo(lon, lat, minLon, minLat, maxLon, maxLat, startYear, endYear);
         return localVarResp.getData();
     }
@@ -209,8 +204,8 @@ public class DeforestationApi {
      * @return DeforestationBasinGeoJSON
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      */
-    public DeforestationBasinGeoJSON lossyearBasinGetSinglePoint(BigDecimal lon, BigDecimal lat) throws ApiException {
-        return lossyearBasinGet(lon, lat, null, null, null, null, null, null);
+    public DeforestationBasinGeoJSON getLossyearBasinSinglePoint(BigDecimal lon, BigDecimal lat) throws ApiException {
+        return getLossyearBasin(lon, lat, null, null, null, null, null, null);
     }
 
     /**
@@ -222,8 +217,8 @@ public class DeforestationApi {
      * @return DeforestationBasinGeoJSON
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      */
-    public DeforestationBasinGeoJSON lossyearBasinGetBoundingBox(BigDecimal minLon, BigDecimal minLat, BigDecimal maxLon, BigDecimal maxLat) throws ApiException {
-        return lossyearBasinGet(null, null, minLon, minLat, maxLon, maxLat, null, null);
+    public DeforestationBasinGeoJSON getLossyearBasinBoundingBox(BigDecimal minLon, BigDecimal minLat, BigDecimal maxLon, BigDecimal maxLat) throws ApiException {
+        return getLossyearBasin(null, null, minLon, minLat, maxLon, maxLat, null, null);
     }
 
     /**
@@ -273,7 +268,7 @@ public class DeforestationApi {
         <tr><td> 422 </td><td> Validation Error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call lossyearBasinGetAsync(BigDecimal lon, BigDecimal lat, BigDecimal minLon, BigDecimal minLat, BigDecimal maxLon, BigDecimal maxLat, Integer startYear, Integer endYear, final ApiCallback<DeforestationBasinGeoJSON> _callback) throws ApiException {
+    public okhttp3.Call getLossyearBasinAsync(BigDecimal lon, BigDecimal lat, BigDecimal minLon, BigDecimal minLat, BigDecimal maxLon, BigDecimal maxLat, Integer startYear, Integer endYear, final ApiCallback<DeforestationBasinGeoJSON> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = lossyearBasinGetValidateBeforeCall(lon, lat, minLon, minLat, maxLon, maxLat, startYear, endYear, _callback);
         Type localVarReturnType = new TypeToken<DeforestationBasinGeoJSON>(){}.getType();
@@ -291,8 +286,8 @@ public class DeforestationApi {
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
      */
-    public okhttp3.Call lossyearBasinGetSinglePointAsync(BigDecimal lon, BigDecimal lat, final ApiCallback<DeforestationBasinGeoJSON> _callback) throws ApiException {
-        return lossyearBasinGetAsync(lon, lat, null, null, null, null, null, null, _callback);
+    public okhttp3.Call getLossyearBasinSinglePointAsync(BigDecimal lon, BigDecimal lat, final ApiCallback<DeforestationBasinGeoJSON> _callback) throws ApiException {
+        return getLossyearBasinAsync(lon, lat, null, null, null, null, null, null, _callback);
     }
 
     /**
@@ -306,7 +301,7 @@ public class DeforestationApi {
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
      */
-    public okhttp3.Call lossyearBasinGetBoundingBoxAsync(BigDecimal minLon, BigDecimal minLat, BigDecimal maxLon, BigDecimal maxLat, final ApiCallback<DeforestationBasinGeoJSON> _callback) throws ApiException {
-        return lossyearBasinGetAsync(null, null, minLon, minLat, maxLon, maxLat, null, null, _callback);
+    public okhttp3.Call getLossyearBasinBoundingBoxAsync(BigDecimal minLon, BigDecimal minLat, BigDecimal maxLon, BigDecimal maxLat, final ApiCallback<DeforestationBasinGeoJSON> _callback) throws ApiException {
+        return getLossyearBasinAsync(null, null, minLon, minLat, maxLon, maxLat, null, null, _callback);
     }
 }

--- a/src/main/java/io/openepi/flood/api/FloodApi.java
+++ b/src/main/java/io/openepi/flood/api/FloodApi.java
@@ -23,12 +23,10 @@ import io.openepi.common.Pair;
 
 import com.google.gson.reflect.TypeToken;
 
-import java.io.IOException;
-
 
 import java.math.BigDecimal;
 import io.openepi.flood.model.DetailedResponseModel;
-import io.openepi.flood.model.HTTPValidationError;
+
 import java.time.LocalDate;
 import io.openepi.flood.model.SummaryResponseModel;
 import io.openepi.flood.model.ThresholdResponseModel;
@@ -204,7 +202,7 @@ public class FloodApi {
         <tr><td> 422 </td><td> Validation Error </td><td>  -  </td></tr>
      </table>
      */
-    public DetailedResponseModel detailedDetailedGet(BigDecimal lon, BigDecimal lat, BigDecimal minLon, BigDecimal maxLon, BigDecimal minLat, BigDecimal maxLat, Boolean includeNeighbors, LocalDate startDate, LocalDate endDate) throws ApiException {
+    public DetailedResponseModel getDetailedForecast(BigDecimal lon, BigDecimal lat, BigDecimal minLon, BigDecimal maxLon, BigDecimal minLat, BigDecimal maxLat, Boolean includeNeighbors, LocalDate startDate, LocalDate endDate) throws ApiException {
         ApiResponse<DetailedResponseModel> localVarResp = detailedDetailedGetWithHttpInfo(lon, lat, minLon, maxLon, minLat, maxLat, includeNeighbors, startDate, endDate);
         return localVarResp.getData();
     }
@@ -219,8 +217,8 @@ public class FloodApi {
      * @return DetailedResponseModel
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      */
-    public DetailedResponseModel detailedDetailedGetSinglePoint(BigDecimal lon, BigDecimal lat, Boolean includeNeighbors) throws ApiException {
-        return detailedDetailedGet(lon, lat, null, null, null, null, includeNeighbors, null, null);
+    public DetailedResponseModel getDetailedForecastSinglePoint(BigDecimal lon, BigDecimal lat, Boolean includeNeighbors) throws ApiException {
+        return getDetailedForecast(lon, lat, null, null, null, null, includeNeighbors, null, null);
     }
 
     /**
@@ -234,8 +232,8 @@ public class FloodApi {
      * @return DetailedResponseModel
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      */
-    public DetailedResponseModel detailedDetailedGetBoundingBox(BigDecimal minLon, BigDecimal maxLon, BigDecimal minLat, BigDecimal maxLat, Boolean includeNeighbors) throws ApiException {
-        return detailedDetailedGet(null, null, minLon, maxLon, minLat, maxLat, includeNeighbors, null, null);
+    public DetailedResponseModel getDetailedForecastBoundingBox(BigDecimal minLon, BigDecimal maxLon, BigDecimal minLat, BigDecimal maxLat, Boolean includeNeighbors) throws ApiException {
+        return getDetailedForecast(null, null, minLon, maxLon, minLat, maxLat, includeNeighbors, null, null);
     }
 
     /**
@@ -287,7 +285,7 @@ public class FloodApi {
         <tr><td> 422 </td><td> Validation Error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call detailedDetailedGetAsync(BigDecimal lon, BigDecimal lat, BigDecimal minLon, BigDecimal maxLon, BigDecimal minLat, BigDecimal maxLat, Boolean includeNeighbors, LocalDate startDate, LocalDate endDate, final ApiCallback<DetailedResponseModel> _callback) throws ApiException {
+    public okhttp3.Call getDetailedForecastAsync(BigDecimal lon, BigDecimal lat, BigDecimal minLon, BigDecimal maxLon, BigDecimal minLat, BigDecimal maxLat, Boolean includeNeighbors, LocalDate startDate, LocalDate endDate, final ApiCallback<DetailedResponseModel> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = detailedDetailedGetValidateBeforeCall(lon, lat, minLon, maxLon, minLat, maxLat, includeNeighbors, startDate, endDate, _callback);
         Type localVarReturnType = new TypeToken<DetailedResponseModel>(){}.getType();
@@ -305,8 +303,8 @@ public class FloodApi {
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
      */
-    public okhttp3.Call detailedDetailedGetSinglePointAsync(BigDecimal lon, BigDecimal lat, Boolean includeNeighbors, final ApiCallback<DetailedResponseModel> _callback) throws ApiException {
-        return detailedDetailedGetAsync(lon, lat, null, null, null, null, includeNeighbors, null, null, _callback);
+    public okhttp3.Call getDetailedForecastSinglePointAsync(BigDecimal lon, BigDecimal lat, Boolean includeNeighbors, final ApiCallback<DetailedResponseModel> _callback) throws ApiException {
+        return getDetailedForecastAsync(lon, lat, null, null, null, null, includeNeighbors, null, null, _callback);
     }
 
     /**
@@ -321,8 +319,8 @@ public class FloodApi {
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
      */
-    public okhttp3.Call detailedDetailedGetBoundingBoxAsync(BigDecimal minLon, BigDecimal maxLon, BigDecimal minLat, BigDecimal maxLat, Boolean includeNeighbors, final ApiCallback<DetailedResponseModel> _callback) throws ApiException {
-        return detailedDetailedGetAsync(null, null, minLon, maxLon, minLat, maxLat, includeNeighbors, null, null, _callback);
+    public okhttp3.Call getDetailedForecastBoundingBoxAsync(BigDecimal minLon, BigDecimal maxLon, BigDecimal minLat, BigDecimal maxLat, Boolean includeNeighbors, final ApiCallback<DetailedResponseModel> _callback) throws ApiException {
+        return getDetailedForecastAsync(null, null, minLon, maxLon, minLat, maxLat, includeNeighbors, null, null, _callback);
     }
 
 
@@ -442,7 +440,7 @@ public class FloodApi {
         <tr><td> 422 </td><td> Validation Error </td><td>  -  </td></tr>
      </table>
      */
-    public SummaryResponseModel summarySummaryGet(BigDecimal lon, BigDecimal lat, BigDecimal minLon, BigDecimal maxLon, BigDecimal minLat, BigDecimal maxLat, Boolean includeNeighbors) throws ApiException {
+    public SummaryResponseModel getForecastSummary(BigDecimal lon, BigDecimal lat, BigDecimal minLon, BigDecimal maxLon, BigDecimal minLat, BigDecimal maxLat, Boolean includeNeighbors) throws ApiException {
         ApiResponse<SummaryResponseModel> localVarResp = summarySummaryGetWithHttpInfo(lon, lat, minLon, maxLon, minLat, maxLat, includeNeighbors);
         return localVarResp.getData();
     }
@@ -456,8 +454,8 @@ public class FloodApi {
      * @return SummaryResponseModel
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      */
-    public SummaryResponseModel summarySummaryGetSinglePoint(BigDecimal lon, BigDecimal lat, Boolean includeNeighbors) throws ApiException {
-        return summarySummaryGet(lon, lat, null, null, null, null, includeNeighbors);
+    public SummaryResponseModel getForecastSummarySinglePoint(BigDecimal lon, BigDecimal lat, Boolean includeNeighbors) throws ApiException {
+        return getForecastSummary(lon, lat, null, null, null, null, includeNeighbors);
     }
 
     /**
@@ -471,8 +469,8 @@ public class FloodApi {
      * @return SummaryResponseModel
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      */
-    public SummaryResponseModel summarySummaryGetBoundingBox(BigDecimal minLon, BigDecimal maxLon, BigDecimal minLat, BigDecimal maxLat, Boolean includeNeighbors) throws ApiException {
-        return summarySummaryGet(null, null, minLon, maxLon, minLat, maxLat, includeNeighbors);
+    public SummaryResponseModel getForecastSummaryBoundingBox(BigDecimal minLon, BigDecimal maxLon, BigDecimal minLat, BigDecimal maxLat, Boolean includeNeighbors) throws ApiException {
+        return getForecastSummary(null, null, minLon, maxLon, minLat, maxLat, includeNeighbors);
     }
 
     /**
@@ -520,7 +518,7 @@ public class FloodApi {
         <tr><td> 422 </td><td> Validation Error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call summarySummaryGetAsync(BigDecimal lon, BigDecimal lat, BigDecimal minLon, BigDecimal maxLon, BigDecimal minLat, BigDecimal maxLat, Boolean includeNeighbors, final ApiCallback<SummaryResponseModel> _callback) throws ApiException {
+    public okhttp3.Call getForecastSummaryAsync(BigDecimal lon, BigDecimal lat, BigDecimal minLon, BigDecimal maxLon, BigDecimal minLat, BigDecimal maxLat, Boolean includeNeighbors, final ApiCallback<SummaryResponseModel> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = summarySummaryGetValidateBeforeCall(lon, lat, minLon, maxLon, minLat, maxLat, includeNeighbors, _callback);
         Type localVarReturnType = new TypeToken<SummaryResponseModel>(){}.getType();
@@ -539,8 +537,8 @@ public class FloodApi {
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
      * @http.response.details
      */
-    public okhttp3.Call summarySummaryGetSinglePointAsync(BigDecimal lon, BigDecimal lat, Boolean includeNeighbors, final ApiCallback<SummaryResponseModel> _callback) throws ApiException {
-        return summarySummaryGetAsync(lon, lat, null, null, null, null, includeNeighbors, _callback);
+    public okhttp3.Call getForecastSummarySinglePointAsync(BigDecimal lon, BigDecimal lat, Boolean includeNeighbors, final ApiCallback<SummaryResponseModel> _callback) throws ApiException {
+        return getForecastSummaryAsync(lon, lat, null, null, null, null, includeNeighbors, _callback);
     }
 
     /**
@@ -555,8 +553,8 @@ public class FloodApi {
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
      */
-    public okhttp3.Call summarySummaryGetBoundingBoxAsync(BigDecimal minLon, BigDecimal maxLon, BigDecimal minLat, BigDecimal maxLat, Boolean includeNeighbors, final ApiCallback<SummaryResponseModel> _callback) throws ApiException {
-        return summarySummaryGetAsync(null, null, minLon, maxLon, minLat, maxLat, includeNeighbors, _callback);
+    public okhttp3.Call getForecastSummaryBoundingBoxAsync(BigDecimal minLon, BigDecimal maxLon, BigDecimal minLat, BigDecimal maxLat, Boolean includeNeighbors, final ApiCallback<SummaryResponseModel> _callback) throws ApiException {
+        return getForecastSummaryAsync(null, null, minLon, maxLon, minLat, maxLat, includeNeighbors, _callback);
     }
 
     /**
@@ -669,7 +667,7 @@ public class FloodApi {
         <tr><td> 422 </td><td> Validation Error </td><td>  -  </td></tr>
      </table>
      */
-    public ThresholdResponseModel thresholdThresholdGet(BigDecimal lon, BigDecimal lat, BigDecimal minLon, BigDecimal maxLon, BigDecimal minLat, BigDecimal maxLat) throws ApiException {
+    public ThresholdResponseModel getThreshold(BigDecimal lon, BigDecimal lat, BigDecimal minLon, BigDecimal maxLon, BigDecimal minLat, BigDecimal maxLat) throws ApiException {
         ApiResponse<ThresholdResponseModel> localVarResp = thresholdThresholdGetWithHttpInfo(lon, lat, minLon, maxLon, minLat, maxLat);
         return localVarResp.getData();
     }
@@ -682,8 +680,8 @@ public class FloodApi {
      * @return ThresholdResponseModel
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      */
-    public ThresholdResponseModel thresholdThresholdGetSinglePoint(BigDecimal lon, BigDecimal lat) throws ApiException {
-        return thresholdThresholdGet(lon, lat, null, null, null, null);
+    public ThresholdResponseModel getThresholdSinglePoint(BigDecimal lon, BigDecimal lat) throws ApiException {
+        return getThreshold(lon, lat, null, null, null, null);
     }
 
     /**
@@ -696,8 +694,8 @@ public class FloodApi {
      * @return ThresholdResponseModel
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      */
-    public ThresholdResponseModel thresholdThresholdGetBoundingBox(BigDecimal minLon, BigDecimal maxLon, BigDecimal minLat, BigDecimal maxLat) throws ApiException {
-        return thresholdThresholdGet(null, null, minLon, maxLon, minLat, maxLat);
+    public ThresholdResponseModel getThresholdBoundingBox(BigDecimal minLon, BigDecimal maxLon, BigDecimal minLat, BigDecimal maxLat) throws ApiException {
+        return getThreshold(null, null, minLon, maxLon, minLat, maxLat);
     }
 
     /**
@@ -743,7 +741,7 @@ public class FloodApi {
         <tr><td> 422 </td><td> Validation Error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call thresholdThresholdGetAsync(BigDecimal lon, BigDecimal lat, BigDecimal minLon, BigDecimal maxLon, BigDecimal minLat, BigDecimal maxLat, final ApiCallback<ThresholdResponseModel> _callback) throws ApiException {
+    public okhttp3.Call getThresholdAsync(BigDecimal lon, BigDecimal lat, BigDecimal minLon, BigDecimal maxLon, BigDecimal minLat, BigDecimal maxLat, final ApiCallback<ThresholdResponseModel> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = thresholdThresholdGetValidateBeforeCall(lon, lat, minLon, maxLon, minLat, maxLat, _callback);
         Type localVarReturnType = new TypeToken<ThresholdResponseModel>(){}.getType();
@@ -761,8 +759,8 @@ public class FloodApi {
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
      */
-    public okhttp3.Call thresholdThresholdGetSinglePointAsync(BigDecimal lon, BigDecimal lat, final ApiCallback<ThresholdResponseModel> _callback) throws ApiException {
-        return thresholdThresholdGetAsync(lon, lat, null, null, null, null, _callback);
+    public okhttp3.Call getThresholdSinglePointAsync(BigDecimal lon, BigDecimal lat, final ApiCallback<ThresholdResponseModel> _callback) throws ApiException {
+        return getThresholdAsync(lon, lat, null, null, null, null, _callback);
     }
 
     /**
@@ -776,7 +774,7 @@ public class FloodApi {
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
      */
-    public okhttp3.Call thresholdThresholdGetBoundingBoxAsync(BigDecimal minLon, BigDecimal maxLon, BigDecimal minLat, BigDecimal maxLat, final ApiCallback<ThresholdResponseModel> _callback) throws ApiException {
-        return thresholdThresholdGetAsync(null, null, minLon, maxLon, minLat, maxLat, _callback);
+    public okhttp3.Call getThresholdBoundingBoxAsync(BigDecimal minLon, BigDecimal maxLon, BigDecimal minLat, BigDecimal maxLat, final ApiCallback<ThresholdResponseModel> _callback) throws ApiException {
+        return getThresholdAsync(null, null, minLon, maxLon, minLat, maxLat, _callback);
     }
 }

--- a/src/main/java/io/openepi/geocoding/api/GeocodingApi.java
+++ b/src/main/java/io/openepi/geocoding/api/GeocodingApi.java
@@ -19,17 +19,12 @@ import io.openepi.common.ApiCallback;
 import io.openepi.common.ApiException;
 import io.openepi.common.ApiResponse;
 import io.openepi.common.Pair;
-import io.openepi.common.ProgressRequestBody;
-import io.openepi.common.ProgressResponseBody;
 
 import com.google.gson.reflect.TypeToken;
-
-import java.io.IOException;
 
 
 import java.math.BigDecimal;
 import io.openepi.geocoding.model.FeatureCollection;
-import io.openepi.geocoding.model.HTTPValidationError;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -183,7 +178,7 @@ public class GeocodingApi {
         <tr><td> 422 </td><td> Validation Error </td><td>  -  </td></tr>
      </table>
      */
-    public FeatureCollection geocodingGet(String q, BigDecimal lat, BigDecimal lon, String lang, Integer limit) throws ApiException {
+    public FeatureCollection getGeocoding(String q, BigDecimal lat, BigDecimal lon, String lang, Integer limit) throws ApiException {
         ApiResponse<FeatureCollection> localVarResp = geocodingGetWithHttpInfo(q, lat, lon, lang, limit);
         return localVarResp.getData();
     }
@@ -195,8 +190,8 @@ public class GeocodingApi {
      * @return FeatureCollection
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      */
-    public FeatureCollection geocodingGet(String q) throws ApiException {
-        return geocodingGet(q, null, null, null, null);
+    public FeatureCollection getGeocoding(String q) throws ApiException {
+        return getGeocoding(q, null, null, null, null);
     }
 
 
@@ -242,7 +237,7 @@ public class GeocodingApi {
         <tr><td> 422 </td><td> Validation Error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call geocodingGetAsync(String q, BigDecimal lat, BigDecimal lon, String lang, Integer limit, final ApiCallback<FeatureCollection> _callback) throws ApiException {
+    public okhttp3.Call getGeocodingAsync(String q, BigDecimal lat, BigDecimal lon, String lang, Integer limit, final ApiCallback<FeatureCollection> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = geocodingGetValidateBeforeCall(q, lat, lon, lang, limit, _callback);
         Type localVarReturnType = new TypeToken<FeatureCollection>(){}.getType();
@@ -257,8 +252,8 @@ public class GeocodingApi {
      * @return FeatureCollection
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      */
-    public okhttp3.Call geocodingGetAsync(String q, final ApiCallback<FeatureCollection> _callback) throws ApiException {
-        return geocodingGetAsync(q, null, null, null, null, _callback);
+    public okhttp3.Call getGeocodingAsync(String q, final ApiCallback<FeatureCollection> _callback) throws ApiException {
+        return getGeocodingAsync(q, null, null, null, null, _callback);
     }
 
 
@@ -370,7 +365,7 @@ public class GeocodingApi {
         <tr><td> 422 </td><td> Validation Error </td><td>  -  </td></tr>
      </table>
      */
-    public FeatureCollection reverseGeocodingReverseGet(BigDecimal lat, BigDecimal lon, String lang, Integer limit) throws ApiException {
+    public FeatureCollection getReverseGeocoding(BigDecimal lat, BigDecimal lon, String lang, Integer limit) throws ApiException {
         ApiResponse<FeatureCollection> localVarResp = reverseGeocodingReverseGetWithHttpInfo(lat, lon, lang, limit);
         return localVarResp.getData();
     }
@@ -415,7 +410,7 @@ public class GeocodingApi {
         <tr><td> 422 </td><td> Validation Error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call reverseGeocodingReverseGetAsync(BigDecimal lat, BigDecimal lon, String lang, Integer limit, final ApiCallback<FeatureCollection> _callback) throws ApiException {
+    public okhttp3.Call getReverseGeocodingAsync(BigDecimal lat, BigDecimal lon, String lang, Integer limit, final ApiCallback<FeatureCollection> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = reverseGeocodingReverseGetValidateBeforeCall(lat, lon, lang, limit, _callback);
         Type localVarReturnType = new TypeToken<FeatureCollection>(){}.getType();

--- a/src/main/java/io/openepi/soil/api/SoilApi.java
+++ b/src/main/java/io/openepi/soil/api/SoilApi.java
@@ -204,7 +204,7 @@ public class SoilApi {
         <tr><td> 422 </td><td> Validation Error </td><td>  -  </td></tr>
      </table>
      */
-    public SoilPropertyJSON getSoilPropertyPropertyGet(BigDecimal lon, BigDecimal lat, List<SoilDepthLabels> depths, List<SoilPropertiesCodes> properties, List<SoilPropertyValueTypes> values) throws ApiException {
+    public SoilPropertyJSON getSoilProperty(BigDecimal lon, BigDecimal lat, List<SoilDepthLabels> depths, List<SoilPropertiesCodes> properties, List<SoilPropertyValueTypes> values) throws ApiException {
         ApiResponse<SoilPropertyJSON> localVarResp = getSoilPropertyPropertyGetWithHttpInfo(lon, lat, depths, properties, values);
         return localVarResp.getData();
     }
@@ -250,7 +250,7 @@ public class SoilApi {
         <tr><td> 422 </td><td> Validation Error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getSoilPropertyPropertyGetAsync(BigDecimal lon, BigDecimal lat, List<SoilDepthLabels> depths, List<SoilPropertiesCodes> properties, List<SoilPropertyValueTypes> values, final ApiCallback<SoilPropertyJSON> _callback) throws ApiException {
+    public okhttp3.Call getSoilPropertyAsync(BigDecimal lon, BigDecimal lat, List<SoilDepthLabels> depths, List<SoilPropertiesCodes> properties, List<SoilPropertyValueTypes> values, final ApiCallback<SoilPropertyJSON> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = getSoilPropertyPropertyGetValidateBeforeCall(lon, lat, depths, properties, values, _callback);
         Type localVarReturnType = new TypeToken<SoilPropertyJSON>(){}.getType();
@@ -361,7 +361,7 @@ public class SoilApi {
 
     /**
      * Get soil type summary
-     * Returns the a summary of the soil types present in the given bounding box, represented by a mapping of each soil type to the number of occurrences in the bounding box
+     * Returns the summary of the soil types present in the given bounding box, represented by a mapping of each soil type to the number of occurrences in the bounding box
      * @param minLon Minimum longitude (required)
      * @param maxLon Maximum longitude (required)
      * @param minLat Minimum latitude (required)
@@ -375,14 +375,14 @@ public class SoilApi {
         <tr><td> 422 </td><td> Validation Error </td><td>  -  </td></tr>
      </table>
      */
-    public SoilTypeSummaryJSON getSoilTypeSummaryTypeSummaryGet(BigDecimal minLon, BigDecimal maxLon, BigDecimal minLat, BigDecimal maxLat) throws ApiException {
+    public SoilTypeSummaryJSON getSoilTypeSummary(BigDecimal minLon, BigDecimal maxLon, BigDecimal minLat, BigDecimal maxLat) throws ApiException {
         ApiResponse<SoilTypeSummaryJSON> localVarResp = getSoilTypeSummaryTypeSummaryGetWithHttpInfo(minLon, maxLon, minLat, maxLat);
         return localVarResp.getData();
     }
 
     /**
      * Get soil type summary
-     * Returns the a summary of the soil types present in the given bounding box, represented by a mapping of each soil type to the number of occurrences in the bounding box
+     * Returns the summary of the soil types present in the given bounding box, represented by a mapping of each soil type to the number of occurrences in the bounding box
      * @param minLon Minimum longitude (required)
      * @param maxLon Maximum longitude (required)
      * @param minLat Minimum latitude (required)
@@ -404,7 +404,7 @@ public class SoilApi {
 
     /**
      * Get soil type summary (asynchronously)
-     * Returns the a summary of the soil types present in the given bounding box, represented by a mapping of each soil type to the number of occurrences in the bounding box
+     * Returns the summary of the soil types present in the given bounding box, represented by a mapping of each soil type to the number of occurrences in the bounding box
      * @param minLon Minimum longitude (required)
      * @param maxLon Maximum longitude (required)
      * @param minLat Minimum latitude (required)
@@ -419,7 +419,7 @@ public class SoilApi {
         <tr><td> 422 </td><td> Validation Error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getSoilTypeSummaryTypeSummaryGetAsync(BigDecimal minLon, BigDecimal maxLon, BigDecimal minLat, BigDecimal maxLat, final ApiCallback<SoilTypeSummaryJSON> _callback) throws ApiException {
+    public okhttp3.Call getSoilTypeSummaryAsync(BigDecimal minLon, BigDecimal maxLon, BigDecimal minLat, BigDecimal maxLat, final ApiCallback<SoilTypeSummaryJSON> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = getSoilTypeSummaryTypeSummaryGetValidateBeforeCall(minLon, maxLon, minLat, maxLat, _callback);
         Type localVarReturnType = new TypeToken<SoilTypeSummaryJSON>(){}.getType();
@@ -528,7 +528,7 @@ public class SoilApi {
         <tr><td> 422 </td><td> Validation Error </td><td>  -  </td></tr>
      </table>
      */
-    public SoilTypeJSON getSoilTypeTypeGet(BigDecimal lon, BigDecimal lat, Integer topK) throws ApiException {
+    public SoilTypeJSON getSoilType(BigDecimal lon, BigDecimal lat, Integer topK) throws ApiException {
         ApiResponse<SoilTypeJSON> localVarResp = getSoilTypeTypeGetWithHttpInfo(lon, lat, topK);
         return localVarResp.getData();
     }
@@ -570,7 +570,7 @@ public class SoilApi {
         <tr><td> 422 </td><td> Validation Error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getSoilTypeTypeGetAsync(BigDecimal lon, BigDecimal lat, Integer topK, final ApiCallback<SoilTypeJSON> _callback) throws ApiException {
+    public okhttp3.Call getSoilTypeAsync(BigDecimal lon, BigDecimal lat, Integer topK, final ApiCallback<SoilTypeJSON> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = getSoilTypeTypeGetValidateBeforeCall(lon, lat, topK, _callback);
         Type localVarReturnType = new TypeToken<SoilTypeJSON>(){}.getType();

--- a/src/main/java/io/openepi/weather/api/WeatherApi.java
+++ b/src/main/java/io/openepi/weather/api/WeatherApi.java
@@ -19,16 +19,12 @@ import io.openepi.common.ApiCallback;
 import io.openepi.common.ApiException;
 import io.openepi.common.ApiResponse;
 import io.openepi.common.Pair;
-import io.openepi.common.ProgressRequestBody;
-import io.openepi.common.ProgressResponseBody;
 
 import com.google.gson.reflect.TypeToken;
 
-import java.io.IOException;
-
 
 import java.math.BigDecimal;
-import io.openepi.weather.model.HTTPValidationError;
+
 import io.openepi.weather.model.METJSONForecast;
 import io.openepi.weather.model.METJSONSunrise;
 
@@ -177,7 +173,7 @@ public class WeatherApi {
         <tr><td> 422 </td><td> Validation Error </td><td>  -  </td></tr>
      </table>
      */
-    public METJSONForecast getForecastLocationforecastGet(BigDecimal lat, BigDecimal lon, Integer altitude) throws ApiException {
+    public METJSONForecast getLocationForecast(BigDecimal lat, BigDecimal lon, Integer altitude) throws ApiException {
         ApiResponse<METJSONForecast> localVarResp = getForecastLocationforecastGetWithHttpInfo(lat, lon, altitude);
         return localVarResp.getData();
     }
@@ -196,8 +192,8 @@ public class WeatherApi {
     <tr><td> 422 </td><td> Validation Error </td><td>  -  </td></tr>
     </table>
      */
-    public METJSONForecast getForecastLocationforecastGet(BigDecimal lat, BigDecimal lon) throws ApiException {
-        return getForecastLocationforecastGet(lat, lon, null);
+    public METJSONForecast getLocationForecast(BigDecimal lat, BigDecimal lon) throws ApiException {
+        return getLocationForecast(lat, lon, null);
     }
 
     /**
@@ -237,7 +233,7 @@ public class WeatherApi {
         <tr><td> 422 </td><td> Validation Error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getForecastLocationforecastGetAsync(BigDecimal lat, BigDecimal lon, Integer altitude, final ApiCallback<METJSONForecast> _callback) throws ApiException {
+    public okhttp3.Call getLocationForecastAsync(BigDecimal lat, BigDecimal lon, Integer altitude, final ApiCallback<METJSONForecast> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = getForecastLocationforecastGetValidateBeforeCall(lat, lon, altitude, _callback);
         Type localVarReturnType = new TypeToken<METJSONForecast>(){}.getType();
@@ -260,8 +256,8 @@ public class WeatherApi {
     <tr><td> 422 </td><td> Validation Error </td><td>  -  </td></tr>
     </table>
      */
-    public okhttp3.Call getForecastLocationforecastGetAsync(BigDecimal lat, BigDecimal lon, final ApiCallback<METJSONForecast> _callback) throws ApiException {
-        return getForecastLocationforecastGetAsync(lat, lon, null, _callback);
+    public okhttp3.Call getLocationForecastAsync(BigDecimal lat, BigDecimal lon, final ApiCallback<METJSONForecast> _callback) throws ApiException {
+        return getLocationForecastAsync(lat, lon, null, _callback);
     }
 
     /**
@@ -366,7 +362,7 @@ public class WeatherApi {
         <tr><td> 422 </td><td> Validation Error </td><td>  -  </td></tr>
      </table>
      */
-    public METJSONSunrise getSunriseSunriseGet(BigDecimal lat, BigDecimal lon, String date) throws ApiException {
+    public METJSONSunrise getSunriseAndSunset(BigDecimal lat, BigDecimal lon, String date) throws ApiException {
         ApiResponse<METJSONSunrise> localVarResp = getSunriseSunriseGetWithHttpInfo(lat, lon, date);
         return localVarResp.getData();
     }
@@ -385,8 +381,8 @@ public class WeatherApi {
     <tr><td> 422 </td><td> Validation Error </td><td>  -  </td></tr>
     </table>
      */
-    public METJSONSunrise getSunriseSunriseGet(BigDecimal lat, BigDecimal lon) throws ApiException {
-        return getSunriseSunriseGet(lat, lon, null);
+    public METJSONSunrise getSunriseAndSunset(BigDecimal lat, BigDecimal lon) throws ApiException {
+        return getSunriseAndSunset(lat, lon, null);
     }
 
     /**
@@ -426,7 +422,7 @@ public class WeatherApi {
         <tr><td> 422 </td><td> Validation Error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getSunriseSunriseGetAsync(BigDecimal lat, BigDecimal lon, String date, final ApiCallback<METJSONSunrise> _callback) throws ApiException {
+    public okhttp3.Call getSunriseAndSunsetAsync(BigDecimal lat, BigDecimal lon, String date, final ApiCallback<METJSONSunrise> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = getSunriseSunriseGetValidateBeforeCall(lat, lon, date, _callback);
         Type localVarReturnType = new TypeToken<METJSONSunrise>(){}.getType();
@@ -449,7 +445,7 @@ public class WeatherApi {
     <tr><td> 422 </td><td> Validation Error </td><td>  -  </td></tr>
     </table>
      */
-    public okhttp3.Call getSunriseSunriseGetAsync(BigDecimal lat, BigDecimal lon, final ApiCallback<METJSONSunrise> _callback) throws ApiException {
-        return getSunriseSunriseGetAsync(lat, lon, null, _callback);
+    public okhttp3.Call getSunriseAndSunsetAsync(BigDecimal lat, BigDecimal lon, final ApiCallback<METJSONSunrise> _callback) throws ApiException {
+        return getSunriseAndSunsetAsync(lat, lon, null, _callback);
     }
 }

--- a/src/test/java/io/openepi/crop_health/api/CropHealthApiTest.java
+++ b/src/test/java/io/openepi/crop_health/api/CropHealthApiTest.java
@@ -43,38 +43,38 @@ public class CropHealthApiTest {
     }
 
     @Test
-    public void predictionsWithBinaryTest() throws ApiException {
+    public void postPredictionBinaryTest() throws ApiException {
         BinaryPredictionResponse mockResponse = new BinaryPredictionResponse();
         mockResponse.setHLT(new BigDecimal("0.5"));
         File body = mock(File.class);
-        when(api.predictionsWithBinary(body)).thenReturn(mockResponse);
+        when(api.postPredictionBinary(body)).thenReturn(mockResponse);
 
-        BinaryPredictionResponse response = api.predictionsWithBinary(body);
+        BinaryPredictionResponse response = api.postPredictionBinary(body);
         assertEquals(new BigDecimal("0.5"), response.getHLT());
     }
 
     @Test
-    public void predictionsWithMultiHLTTest() throws ApiException {
+    public void postPredictionMultiTest() throws ApiException {
         MultiHLTPredictionResponse mockResponse = new MultiHLTPredictionResponse();
         mockResponse.setAlSBeans(new BigDecimal("0.5"));
         mockResponse.setAnTCocoa(new BigDecimal("0.5"));
         File body = mock(File.class);
-        when(api.predictionsWithMultiHLT(body)).thenReturn(mockResponse);
+        when(api.postPredictionMulti(body)).thenReturn(mockResponse);
 
-        MultiHLTPredictionResponse response = api.predictionsWithMultiHLT(body);
+        MultiHLTPredictionResponse response = api.postPredictionMulti(body);
         assertEquals(new BigDecimal("0.5"), response.getAlSBeans());
         assertEquals(new BigDecimal("0.5"), response.getAnTCocoa());
     }
 
     @Test
-    public void predictionsWithSingleHLTTest() throws ApiException {
+    public void postPredictionSingleTest() throws ApiException {
         SingleHLTPredictionResponse mockResponse = new SingleHLTPredictionResponse();
         mockResponse.setHLT(new BigDecimal("0.5"));
         mockResponse.setALS(new BigDecimal("0.5"));
         File body = mock(File.class);
-        when(api.predictionsWithSingleHLT(body)).thenReturn(mockResponse);
+        when(api.postPredictionSingle(body)).thenReturn(mockResponse);
 
-        SingleHLTPredictionResponse response = api.predictionsWithSingleHLT(body);
+        SingleHLTPredictionResponse response = api.postPredictionSingle(body);
         assertEquals(new BigDecimal("0.5"), response.getHLT());
         assertEquals(new BigDecimal("0.5"), response.getALS());
     }

--- a/src/test/java/io/openepi/deforestation/api/DeforestationApiTest.java
+++ b/src/test/java/io/openepi/deforestation/api/DeforestationApiTest.java
@@ -30,7 +30,7 @@ public class DeforestationApiTest {
     }
 
     @Test
-    public void lossyearBasinGetTest() throws ApiException {
+    public void getLossyearBasinTest() throws ApiException {
         BigDecimal lon = new BigDecimal("30.06");
         BigDecimal lat = BigDecimal.valueOf(-1.94);
         BigDecimal minLon = new BigDecimal("28.85");
@@ -49,13 +49,13 @@ public class DeforestationApiTest {
         features.add(mockFeature);
         mockResponse.setFeatures(features);
 
-        when(api.lossyearBasinGet(lon, lat, null, null, null, null, null, null)).thenReturn(mockResponse);
-        when(api.lossyearBasinGet(null, null, minLon, minLat, maxLon, maxLat, null, null)).thenReturn(mockResponse);
+        when(api.getLossyearBasin(lon, lat, null, null, null, null, null, null)).thenReturn(mockResponse);
+        when(api.getLossyearBasin(null, null, minLon, minLat, maxLon, maxLat, null, null)).thenReturn(mockResponse);
 
-        DeforestationBasinGeoJSON response = api.lossyearBasinGet(lon, lat, null, null, null, null, null, null);
+        DeforestationBasinGeoJSON response = api.getLossyearBasin(lon, lat, null, null, null, null, null, null);
         assertEquals(response.getFeatures().get(0).getProperties().getStartYear(), 2001);
 
-        response = api.lossyearBasinGet(null, null, minLon, minLat, maxLon, maxLat, null, null);
+        response = api.getLossyearBasin(null, null, minLon, minLat, maxLon, maxLat, null, null);
         assertEquals(2001, response.getFeatures().get(0).getProperties().getStartYear());
     }
 

--- a/src/test/java/io/openepi/flood/api/FloodApiTest.java
+++ b/src/test/java/io/openepi/flood/api/FloodApiTest.java
@@ -28,7 +28,7 @@ public class FloodApiTest {
     }
 
     @Test
-    public void detailedDetailedGetTest() throws ApiException {
+    public void getDetailedForecastTest() throws ApiException {
         BigDecimal lon = new BigDecimal("33.57");
         BigDecimal lat = BigDecimal.valueOf(-1.37);
         Boolean includeNeighbors = false;
@@ -45,19 +45,19 @@ public class FloodApiTest {
         mockFeatureCollection.addFeaturesItem(mockFeature);
         mockResponse.setQueriedLocation(mockFeatureCollection);
 
-        when(api.detailedDetailedGet(lon, lat, null, null, null, null, includeNeighbors, null, null)).thenReturn(mockResponse);
-        when(api.detailedDetailedGet(null, null, minLon, maxLon, minLat, maxLat, includeNeighbors, null, null)).thenReturn(mockResponse);
+        when(api.getDetailedForecast(lon, lat, null, null, null, null, includeNeighbors, null, null)).thenReturn(mockResponse);
+        when(api.getDetailedForecast(null, null, minLon, maxLon, minLat, maxLat, includeNeighbors, null, null)).thenReturn(mockResponse);
 
-        DetailedResponseModel response = api.detailedDetailedGet(lon, lat, null, null, null, null, includeNeighbors, null, null);
+        DetailedResponseModel response = api.getDetailedForecast(lon, lat, null, null, null, null, includeNeighbors, null, null);
         assertEquals("123", response.getQueriedLocation().getFeatures().get(0).getId());
 
-        response = api.detailedDetailedGet(null, null, minLon, maxLon, minLat, maxLat, includeNeighbors, null, null);
+        response = api.getDetailedForecast(null, null, minLon, maxLon, minLat, maxLat, includeNeighbors, null, null);
         assertEquals("123", response.getQueriedLocation().getFeatures().get(0).getId());
     }
 
 
     @Test
-    public void summarySummaryGetTest() throws ApiException {
+    public void getForecastSummaryTest() throws ApiException {
         BigDecimal lon = new BigDecimal("33.57");
         BigDecimal lat = BigDecimal.valueOf(-1.37);
         Boolean includeNeighbors = false;
@@ -74,18 +74,18 @@ public class FloodApiTest {
         mockFeatureCollection.addFeaturesItem(mockFeature);
         mockResponse.setQueriedLocation(mockFeatureCollection);
 
-        when(api.summarySummaryGet(lon, lat, null, null, null, null, includeNeighbors)).thenReturn(mockResponse);
-        when(api.summarySummaryGet(null, null, minLon, maxLon, minLat, maxLat, includeNeighbors)).thenReturn(mockResponse);
+        when(api.getForecastSummary(lon, lat, null, null, null, null, includeNeighbors)).thenReturn(mockResponse);
+        when(api.getForecastSummary(null, null, minLon, maxLon, minLat, maxLat, includeNeighbors)).thenReturn(mockResponse);
 
-        SummaryResponseModel response = api.summarySummaryGet(lon, lat, null, null, null, null, includeNeighbors);
+        SummaryResponseModel response = api.getForecastSummary(lon, lat, null, null, null, null, includeNeighbors);
         assertEquals("123", response.getQueriedLocation().getFeatures().get(0).getId());
 
-        response = api.summarySummaryGet(null, null, minLon, maxLon, minLat, maxLat, includeNeighbors);
+        response = api.getForecastSummary(null, null, minLon, maxLon, minLat, maxLat, includeNeighbors);
         assertEquals("123", response.getQueriedLocation().getFeatures().get(0).getId());
     }
 
     @Test
-    public void thresholdThresholdGetTest() throws ApiException {
+    public void getThresholdTest() throws ApiException {
         BigDecimal lon = new BigDecimal("33.57");
         BigDecimal lat = BigDecimal.valueOf(-1.37);
 
@@ -101,13 +101,13 @@ public class FloodApiTest {
         mockFeatureCollection.addFeaturesItem(mockFeature);
         mockResponse.setQueriedLocation(mockFeatureCollection);
 
-        when(api.thresholdThresholdGet(lon, lat, null, null, null, null)).thenReturn(mockResponse);
-        when(api.thresholdThresholdGet(null, null, minLon, maxLon, minLat, maxLat)).thenReturn(mockResponse);
+        when(api.getThreshold(lon, lat, null, null, null, null)).thenReturn(mockResponse);
+        when(api.getThreshold(null, null, minLon, maxLon, minLat, maxLat)).thenReturn(mockResponse);
 
-        ThresholdResponseModel response = api.thresholdThresholdGet(lon, lat, null, null, null, null);
+        ThresholdResponseModel response = api.getThreshold(lon, lat, null, null, null, null);
         assertEquals("123", response.getQueriedLocation().getFeatures().get(0).getId());
 
-        response = api.thresholdThresholdGet(null, null, minLon, maxLon, minLat, maxLat);
+        response = api.getThreshold(null, null, minLon, maxLon, minLat, maxLat);
         assertEquals("123", response.getQueriedLocation().getFeatures().get(0).getId());
     }
 

--- a/src/test/java/io/openepi/geocoding/api/GeocodingApiTest.java
+++ b/src/test/java/io/openepi/geocoding/api/GeocodingApiTest.java
@@ -28,7 +28,7 @@ public class GeocodingApiTest {
     }
 
     @Test
-    public void geocodingGetTest() throws ApiException {
+    public void getGeocodingTest() throws ApiException {
         String q = "Kigali, Rwanda";
 
         FeatureCollection mockResponse = new FeatureCollection();
@@ -41,14 +41,14 @@ public class GeocodingApiTest {
         List<Feature> mockFeatures = Arrays.asList(mockFeature);
         mockResponse.setFeatures(mockFeatures);
 
-        when(api.geocodingGet(q, null, null, null, null)).thenReturn(mockResponse);
+        when(api.getGeocoding(q, null, null, null, null)).thenReturn(mockResponse);
 
-        FeatureCollection response = api.geocodingGet(q, null, null, null, null);
+        FeatureCollection response = api.getGeocoding(q, null, null, null, null);
         assertEquals(Arrays.asList("-1.97", "30.10"), response.getFeatures().get(0).getGeometry().getPoint().getCoordinates());
     }
 
     @Test
-    public void reverseGeocodingReverseGetTest() throws ApiException {
+    public void getReverseGeocodingTest() throws ApiException {
         BigDecimal lat = new BigDecimal("-1.97");
         BigDecimal lon = new BigDecimal("30.10");
 
@@ -60,9 +60,9 @@ public class GeocodingApiTest {
         List<Feature> mockFeatures = Arrays.asList(mockFeature);
         mockResponse.setFeatures(mockFeatures);
 
-        when(api.reverseGeocodingReverseGet(lat, lon, null, null)).thenReturn(mockResponse);
+        when(api.getReverseGeocoding(lat, lon, null, null)).thenReturn(mockResponse);
 
-        FeatureCollection response = api.reverseGeocodingReverseGet(lat, lon, null, null);
+        FeatureCollection response = api.getReverseGeocoding(lat, lon, null, null);
         assertEquals("RW", response.getFeatures().get(0).getProperties().getCountrycode());
     }
 

--- a/src/test/java/io/openepi/soil/api/SoilApiTest.java
+++ b/src/test/java/io/openepi/soil/api/SoilApiTest.java
@@ -27,7 +27,7 @@ public class SoilApiTest {
     }
 
     @Test
-    public void getSoilPropertyPropertyGetTest() throws ApiException {
+    public void getSoilPropertyTest() throws ApiException {
         BigDecimal lon = new BigDecimal(9.58);
         BigDecimal lat = new BigDecimal(60.1);
         List<SoilDepthLabels> depths = Arrays.asList(SoilDepthLabels._0_5CM);
@@ -41,15 +41,15 @@ public class SoilApiTest {
         layerList.addLayersItem(layer);
         mockResponse.setProperties(layerList);
 
-        when(api.getSoilPropertyPropertyGet(lon, lat, depths, properties, values)).thenReturn(mockResponse);
+        when(api.getSoilProperty(lon, lat, depths, properties, values)).thenReturn(mockResponse);
 
-        SoilPropertyJSON response = api.getSoilPropertyPropertyGet(lon, lat, depths, properties, values);
+        SoilPropertyJSON response = api.getSoilProperty(lon, lat, depths, properties, values);
         assertEquals(SoilPropertiesCodes.BDOD, response.getProperties().getLayers().get(0).getCode());
     }
 
 
     @Test
-    public void getSoilTypeSummaryTypeSummaryGetTest() throws ApiException {
+    public void getSoilTypeSummaryTest() throws ApiException {
         BigDecimal minLon = new BigDecimal("9.5");
         BigDecimal maxLon = new BigDecimal("9.6");
         BigDecimal minLat = new BigDecimal("60.1");
@@ -62,15 +62,15 @@ public class SoilApiTest {
         type.addSummariesItem(summary);
         mockResponse.setProperties(type);
 
-        when(api.getSoilTypeSummaryTypeSummaryGet(minLon, maxLon, minLat, maxLat)).thenReturn(mockResponse);
+        when(api.getSoilTypeSummary(minLon, maxLon, minLat, maxLat)).thenReturn(mockResponse);
 
-        SoilTypeSummaryJSON response = api.getSoilTypeSummaryTypeSummaryGet(minLon, maxLon, minLat, maxLat);
+        SoilTypeSummaryJSON response = api.getSoilTypeSummary(minLon, maxLon, minLat, maxLat);
         assertEquals(SoilTypes.ALBELUVISOLS, response.getProperties().getSummaries().get(0).getSoilType());
     }
 
 
     @Test
-    public void getSoilTypeTypeGetTest() throws ApiException {
+    public void getSoilTypeTest() throws ApiException {
         BigDecimal lon = new BigDecimal("9.58");
         BigDecimal lat = new BigDecimal("60.1");
 
@@ -79,8 +79,8 @@ public class SoilApiTest {
         type.setMostProbableSoilType(SoilTypes.ALBELUVISOLS);
         mockResponse.setProperties(type);
 
-        when(api.getSoilTypeTypeGet(lon, lat, null)).thenReturn(mockResponse);
-        SoilTypeJSON response = api.getSoilTypeTypeGet(lon, lat, null);
+        when(api.getSoilType(lon, lat, null)).thenReturn(mockResponse);
+        SoilTypeJSON response = api.getSoilType(lon, lat, null);
 
         assertEquals(SoilTypes.ALBELUVISOLS, response.getProperties().getMostProbableSoilType());
     }

--- a/src/test/java/io/openepi/weather/api/WeatherApiTest.java
+++ b/src/test/java/io/openepi/weather/api/WeatherApiTest.java
@@ -25,7 +25,7 @@ public class WeatherApiTest {
     }
 
     @Test
-    public void getForecastLocationforecastGetTest() throws ApiException {
+    public void getLocationForecastTest() throws ApiException {
         BigDecimal lat = new BigDecimal("52.52");
         BigDecimal lon = new BigDecimal("13.40");
 
@@ -42,15 +42,15 @@ public class WeatherApiTest {
         forecast.addTimeseriesItem(forecastTimeStep);
         mockResponse.setProperties(forecast);
 
-        when(api.getForecastLocationforecastGet(lat, lon, null)).thenReturn(mockResponse);
+        when(api.getLocationForecast(lat, lon, null)).thenReturn(mockResponse);
 
-        METJSONForecast response = api.getForecastLocationforecastGet(lat, lon, null);
+        METJSONForecast response = api.getLocationForecast(lat, lon, null);
         assertEquals(new BigDecimal("10"), response.getProperties().getTimeseries().get(0).getData().getInstant().getDetails().getAirPressureAtSeaLevel());
 
     }
 
     @Test
-    public void getSunriseSunriseGetTest() throws ApiException {
+    public void getSunriseAndSunsetTest() throws ApiException {
         BigDecimal lat = new BigDecimal("52.52");
         BigDecimal lon = new BigDecimal("13.40");
 
@@ -61,9 +61,9 @@ public class WeatherApiTest {
         forecast.setSunrise(mockTime);
         mockResponse.setProperties(forecast);
 
-        when(api.getSunriseSunriseGet(lat, lon, null)).thenReturn(mockResponse);
+        when(api.getSunriseAndSunset(lat, lon, null)).thenReturn(mockResponse);
 
-        METJSONSunrise response = api.getSunriseSunriseGet(lat, lon, null);
+        METJSONSunrise response = api.getSunriseAndSunset(lat, lon, null);
         assertEquals("20:24", response.getProperties().getSunrise().getTime());
     }
 


### PR DESCRIPTION
Renames almost all public methods for all the apis as the autogenerated methodnames did not make much sense. 

Also updates the name of test to reflect the new method names, and updates the examples in the readme.